### PR TITLE
Add build artifacts to release

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04 # Using LTS version for better stability
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout Repository
@@ -119,6 +121,20 @@ jobs:
         with:
           name: DietBook EPUB
           path: ./DietBook.epub
+
+      - name: Publish Latest prerelease (master)
+        if: github.ref == 'refs/heads/master'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: latest
+          name: Latest build
+          draft: false
+          prerelease: true
+          allowUpdates: true
+          replacesArtifacts: true
+          generateReleaseNotes: false
+          artifacts: "DietBook.pdf,DietBook.epub"
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release Book Formats
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Publish build artifacts to a rolling 'Latest' prerelease to make them downloadable from GitHub Releases.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee54b041-5698-4c08-b745-cbb9376370eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee54b041-5698-4c08-b745-cbb9376370eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

